### PR TITLE
Free Timeslots Endpoint

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -19,6 +19,21 @@ class User(UserMixin, Document):
             "user_id": self.user_id
         })
 
+class Interval:
+    def __init__(self, start, end, id, duration):
+        self.start = start
+        self.end = end
+        self.id = id
+        self.duration = duration
+    
+    def toJSON(self):
+        return jsonify({
+            "start": self.start,
+            "end": self.end,
+            "id": self.id,
+            "duration": self.duration
+        })
+
 class Error(Exception):
     status_code = 400
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -86,7 +86,7 @@ def get_free_intervals(id):
             raise ValueError("Could not get events from Calendar API", status_code = 500)
         events = events_result.get('items', [])
 
-        return jsonify(formulate_open_timeslots(events, today))
+        return jsonify([timeslot.__dict__ for timeslot in formulate_open_timeslots(events, today)]), 200
 
 
     except ValueError as e:

--- a/backend/app/util.py
+++ b/backend/app/util.py
@@ -1,6 +1,9 @@
 from dateutil import parser
+from .models import Interval
 from pytz import timezone
 import datetime, time, pytz
+
+
 
 def convertDateToRFC3339(date):
     # Parse date into datetime object
@@ -12,12 +15,18 @@ def convertDateToRFC3339(date):
 def convertDateTimeToRFC3339(date_time):
     return date_time.astimezone(tz=pytz.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
+def duration(start, end):
+    difference_seconds = (end - start).total_seconds()
+    hours, leftover_seconds = divmod(difference_seconds, 3600)
+    return float(hours) + float(leftover_seconds/3600)
+
 def formulate_open_timeslots(events, current_date):
     time_slots = []
     local_timezone = timezone('US/Pacific')
     start_time = local_timezone.localize(datetime.datetime.combine(current_date, datetime.time(7, 0)))   # beginning of first interval is 7am day 1
     end_time = local_timezone.localize(datetime.datetime.combine(current_date + datetime.timedelta(days = 1), datetime.time(0, 0))) #end of first interval is beginning of next day
     curr_interval = (start_time, end_time)
+    i = 1
 
     for event in events:
         event_start = parser.parse(event['start']['dateTime']).astimezone(local_timezone) #assume event time is PST timezone
@@ -26,14 +35,14 @@ def formulate_open_timeslots(events, current_date):
         if event_start > curr_interval[0]:
             new_interval = (event_end, curr_interval[1])
             changed_curr_interval = (curr_interval[0], event_start)
-            time_slots.append(changed_curr_interval)
+            time_slots.append(Interval(changed_curr_interval[0], changed_curr_interval[1], i, duration(changed_curr_interval[0], changed_curr_interval[1])))
+
+            i += 1
             curr_interval = new_interval
         elif event_end > curr_interval[0]:
             new_interval = (event_end, curr_interval[1])
             curr_interval = new_interval
 
-    time_slots.append(curr_interval)
-
-    print(time_slots)
+    time_slots.append(Interval(curr_interval[0], curr_interval[1], i, duration(curr_interval[0], curr_interval[1])))
 
     return time_slots

--- a/backend/app/util.py
+++ b/backend/app/util.py
@@ -1,9 +1,39 @@
 from dateutil import parser
-import datetime, time
+from pytz import timezone
+import datetime, time, pytz
 
 def convertDateToRFC3339(date):
     # Parse date into datetime object
     date_time = parser.parse(date)
 
     # Return RFC3339 date after switching to UTC format
-    return datetime.datetime.utcfromtimestamp(time.mktime(date_time.timetuple())).isoformat('T') + 'Z'
+    return date_time.astimezone(tz=pytz.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+def convertDateTimeToRFC3339(date_time):
+    return date_time.astimezone(tz=pytz.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+def formulate_open_timeslots(events, current_date):
+    time_slots = []
+    local_timezone = timezone('US/Pacific')
+    start_time = local_timezone.localize(datetime.datetime.combine(current_date, datetime.time(7, 0)))   # beginning of first interval is 7am day 1
+    end_time = local_timezone.localize(datetime.datetime.combine(current_date + datetime.timedelta(days = 1), datetime.time(0, 0))) #end of first interval is beginning of next day
+    curr_interval = (start_time, end_time)
+
+    for event in events:
+        event_start = parser.parse(event['start']['dateTime']).astimezone(local_timezone) #assume event time is PST timezone
+        event_end = parser.parse(event['end']['dateTime']).astimezone(local_timezone) #assume event time is PST timezone
+
+        if event_start > curr_interval[0]:
+            new_interval = (event_end, curr_interval[1])
+            changed_curr_interval = (curr_interval[0], event_start)
+            time_slots.append(changed_curr_interval)
+            curr_interval = new_interval
+        elif event_end > curr_interval[0]:
+            new_interval = (event_end, curr_interval[1])
+            curr_interval = new_interval
+
+    time_slots.append(curr_interval)
+
+    print(time_slots)
+
+    return time_slots

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,6 +21,7 @@ pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pymongo==3.7.2
 python-dateutil==2.8.0
+pytz==2019.1
 requests==2.21.0
 requests-oauthlib==1.2.0
 rsa==4.0


### PR DESCRIPTION
* Created endpoint `/free_intervals/id=<id>`, that gets a list of free time intervals for a user for the current day.
* Returns list of Interval objects that contain `start` and `end` times along with `duration` and and `id` for use in the constrain satisfaction problem. 